### PR TITLE
feat(cli)!: adopt factories with ModuleCreator; add --strict and verbose dep logs

### DIFF
--- a/packages/smf_flutter_cli/bin/smf_flutter.dart
+++ b/packages/smf_flutter_cli/bin/smf_flutter.dart
@@ -11,8 +11,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
 import 'package:smf_flutter_cli/commands/smf_command_runner.dart';
 
 Future<void> main(List<String> arguments) async {
-  await SMFCommandRunner().run(arguments);
+  try {
+    await SMFCommandRunner().run(arguments);
+  } on UsageException catch (e) {
+    exit(64);
+  } on FormatException catch (e) {
+    exit(64);
+  } on ProcessException catch (e) {
+    exit(1);
+  } on Exception catch (e) {
+    exit(1);
+  }
 }

--- a/packages/smf_flutter_cli/lib/cli_engine.dart
+++ b/packages/smf_flutter_cli/lib/cli_engine.dart
@@ -35,6 +35,7 @@ Future<void> runCli(CliContext context) async {
         '[${resolvedModules.map((e) => "'${e.moduleDescriptor.name}'").join(',')}]',
     'app_name': context.name,
     'org_name': context.packageName,
+    'strict_mode': context.strictMode == StrictMode.strict,
   };
   await cliGenerator.hooks.preGen(
     vars: coreVars,

--- a/packages/smf_flutter_cli/lib/commands/create.dart
+++ b/packages/smf_flutter_cli/lib/commands/create.dart
@@ -16,8 +16,11 @@ import 'dart:core';
 import 'package:smf_contracts/smf_contracts.dart';
 import 'package:smf_flutter_cli/cli_engine.dart';
 import 'package:smf_flutter_cli/commands/base.dart';
+import 'package:smf_flutter_cli/constants/smf_modules.dart';
 import 'package:smf_flutter_cli/promts/create_prompt.dart';
 import 'package:smf_flutter_cli/promts/models/cli_context.dart';
+import 'package:smf_flutter_cli/utils/module_creator.dart';
+import 'package:smf_flutter_cli/utils/module_dependency_resolver.dart';
 
 /// CLI command that scaffolds a new Flutter app using Say My Frame modules.
 final class CreateCommand extends BaseCommand {
@@ -65,11 +68,22 @@ final class CreateCommand extends BaseCommand {
 
   @override
   Future<void> run() async {
-    final preferences = CreatePrompt().prompt(
+    final isStrict = (globalResults?['strict'] as bool?) ?? false;
+    final moduleCreator = ModuleCreator(
+      const ModuleDependencyResolver(),
+      smfModules,
+      coreModuleKeys: const [
+        kFlutterCoreModule,
+        kContractsModule,
+      ],
+    );
+    final preferences = CreatePrompt(creator: moduleCreator).prompt(
       argResults,
       allowedModules: allowedModules,
+      strictMode: isStrict ? StrictMode.strict : StrictMode.lenient,
+      logger: logger,
     );
-
+    
     return runCli(
       CliContext(
         name: preferences.name,
@@ -77,6 +91,7 @@ final class CreateCommand extends BaseCommand {
         selectedModules: preferences.selectedModules,
         outputDirectory: argResults?['output'] as String? ?? './',
         initialRoute: preferences.initialRoute,
+        strictMode: isStrict ? StrictMode.strict : StrictMode.lenient,
         logger: logger,
       ),
     );

--- a/packages/smf_flutter_cli/lib/commands/smf_command_runner.dart
+++ b/packages/smf_flutter_cli/lib/commands/smf_command_runner.dart
@@ -33,6 +33,11 @@ class SMFCommandRunner extends CommandRunner<void> {
         help: 'Enable verbose logging.',
       )
       ..addFlag(
+        'strict',
+        negatable: false,
+        help: 'Enable strict mode for module compatibility checks.',
+      )
+      ..addFlag(
         'version',
         abbr: 'v',
         negatable: false,

--- a/packages/smf_flutter_cli/lib/constants/smf_modules.dart
+++ b/packages/smf_flutter_cli/lib/constants/smf_modules.dart
@@ -18,18 +18,18 @@ import 'package:smf_firebase_core/smf_firebase_core.dart';
 import 'package:smf_flutter_core/smf_flutter_core.dart';
 import 'package:smf_get_it/smf_get_it.dart';
 import 'package:smf_go_router/smf_go_router.dart';
-import 'package:smf_home_flutter/smf_home_flutter.dart';
+import 'package:smf_home_flutter/smf_home_module.dart';
 
 /// Registry of available SMF modules keyed by their public identifiers.
-final smfModules = <String, IModuleCodeContributor>{
-  kFirebaseCore: FirebaseCoreModule(),
-  kFirebaseAnalytics: FirebaseAnalyticsModule(),
-  kFlutterCoreModule: SmfCoreModule(),
-  kGetItModule: SmfGetItModule(),
-  kCommunicationModule: SmfEventBusModule(),
-  kGoRouterModule: SmfGoRouterModule(),
-  kHomeFeatureModule: SmfHomeFlutterModule(),
-  kContractsModule: SmfContractsModule(),
+final smfModules = <String, IModuleContributorFactory>{
+  kFirebaseCore: SmfFirebaseCoreFactory(),
+  kFirebaseAnalytics: SmfFirebaseAnalyticsFactory(),
+  kFlutterCoreModule: SmfFlutterCoreFactory(),
+  kGetItModule: SmfGetItFactory(),
+  kCommunicationModule: SmfEventBusFactory(),
+  kGoRouterModule: SmfGoRouterFactory(),
+  kHomeFeatureModule: SmfHomeModuleFactory(),
+  kContractsModule: SmfContractsFactory(),
 };
 
 /// Supported state management options that can be applied in templates.

--- a/packages/smf_flutter_cli/lib/generators/dsl_generator.dart
+++ b/packages/smf_flutter_cli/lib/generators/dsl_generator.dart
@@ -31,6 +31,7 @@ class DslGenerator extends Generator {
 
   /// Write strategy used for persisting generated files.
   final CompositeWriteStrategy strategy;
+
   /// Execution context with CLI-level preferences.
   final CliContext cliContext;
 

--- a/packages/smf_flutter_cli/lib/promts/create_prompt.dart
+++ b/packages/smf_flutter_cli/lib/promts/create_prompt.dart
@@ -2,30 +2,45 @@ import 'dart:io' show stdout;
 
 import 'package:args/args.dart';
 import 'package:interact/interact.dart';
+import 'package:mason/mason.dart';
 import 'package:smf_contracts/smf_contracts.dart';
 import 'package:smf_flutter_cli/constants/smf_modules.dart';
+import 'package:smf_flutter_cli/promts/models/cli_context.dart';
 import 'package:smf_flutter_cli/promts/models/project_preferences.dart';
 import 'package:smf_flutter_cli/promts/theme.dart';
-import 'package:smf_flutter_core/smf_flutter_core.dart';
+import 'package:smf_flutter_cli/utils/module_creator.dart';
 
 /// Interactive prompt that gathers project preferences from the user.
 class CreatePrompt {
+  const CreatePrompt({required this.creator});
+
+  final ModuleCreator creator;
+
   /// Starts the prompt flow and returns collected [ProjectPreferences].
   ProjectPreferences prompt(
     ArgResults? argResult, {
     required List<String> allowedModules,
+    required StrictMode strictMode,
+    required Logger logger,
   }) {
     stdout.writeln(
       "👋 Hello! Let's create a flutter project with Say my Frame.",
     );
 
-    return _collect(argResult, allowedModules: allowedModules);
+    return _collect(
+      argResult,
+      allowedModules: allowedModules,
+      strictMode: strictMode,
+      logger: logger,
+    );
   }
 
   /// Collects values from CLI flags or interacts with the user when missing.
   ProjectPreferences _collect(
     ArgResults? argResult, {
     required List<String> allowedModules,
+    required StrictMode strictMode,
+    required Logger logger,
   }) {
     final name = argResult?.rest.firstOrNull ??
         Input.withTheme(
@@ -45,46 +60,71 @@ class CreatePrompt {
         Input.withTheme(
           prompt: '🏢 Enter package name: ',
           theme: terminalTheme,
-          defaultValue: 'com.example.$name',
+          defaultValue: 'com.example',
         ).interact();
 
-    var selectedModules = _selectedModules(
+    var selectedFactories = _selectedModules(
       argResult,
       allowedModules: allowedModules,
     );
 
-    if (selectedModules.isEmpty) {
+    if (selectedFactories.isEmpty) {
       final modules = MultiSelect.withTheme(
         prompt: '📦 Select modules',
         options: allowedModules,
         theme: terminalTheme,
       ).interact();
 
-      selectedModules = _resolveModule(
+      selectedFactories = _resolveModule(
         modules.map((i) => allowedModules[i]).toList(),
       );
     }
 
-    final initialRoute =
-        argResult?['route'] as String? ?? _initialRoute(selectedModules);
+    // Select state manager (default to BLoC)
+    final stateIndex = Select.withTheme(
+      prompt: '🧠 Choose state manager',
+      options: smfStateManagers,
+      theme: terminalTheme,
+    ).interact();
+    final selectedState = smfStateManagers[stateIndex];
+    final profile = ModuleProfile(
+      stateManager: selectedState == kRiverpodStateManagement
+          ? StateManager.riverpod
+          : StateManager.bloc,
+    );
+
+    // Build module instances using ModuleCreator
+    final modules = creator.build(
+      selectedFactories,
+      profile,
+      strictMode: strictMode,
+      logger: logger,
+    );
+
+    final initialRoute = argResult?['route'] as String? ??
+        _initialRoute(
+          modules,
+          coreModules: creator.coreModuleKeys,
+        );
 
     return ProjectPreferences(
       name: name,
       packageName: packageName,
-      selectedModules: [
-        SmfCoreModule(),
-        SmfContractsModule(),
-        ...selectedModules
-      ],
+      selectedModules: modules,
       initialRoute: initialRoute,
     );
   }
 
   /// Requests the initial route from user based on selected modules.
-  String _initialRoute(List<IModuleCodeContributor> modules) {
+  String _initialRoute(
+    List<IModuleCodeContributor> modules, {
+    required List<String> coreModules,
+  }) {
     final modulesWithInitialRoute = modules
         .where((m) => m.routes.initialRoute?.isNotEmpty ?? false)
-        .toList();
+        .toList()
+      // To prevent asking for the initial route from core modules
+      ..removeWhere((m) => coreModules.contains(m.moduleDescriptor.name));
 
     final initialRoute = Select.withTheme(
       prompt: '🧭 Choose your initial screen',
@@ -97,7 +137,7 @@ class CreatePrompt {
   }
 
   /// Parses the `--modules` argument and validates allowed module names.
-  List<IModuleCodeContributor> _selectedModules(
+  List<IModuleContributorFactory> _selectedModules(
     ArgResults? argResult, {
     required List<String> allowedModules,
   }) {
@@ -133,7 +173,7 @@ class CreatePrompt {
   }
 
   /// Maps module names to their implementations using the registry.
-  List<IModuleCodeContributor> _resolveModule(List<String> modules) {
+  List<IModuleContributorFactory> _resolveModule(List<String> modules) {
     return modules.map((e) {
       final module = smfModules[e];
       if (module == null) {

--- a/packages/smf_flutter_cli/lib/promts/models/cli_context.dart
+++ b/packages/smf_flutter_cli/lib/promts/models/cli_context.dart
@@ -1,6 +1,8 @@
 import 'package:mason/mason.dart';
 import 'package:smf_contracts/smf_contracts.dart';
 
+enum StrictMode { strict, lenient }
+
 /// Execution context passed across generators and hooks.
 class CliContext {
   /// Creates a new [CliContext].
@@ -9,20 +11,29 @@ class CliContext {
     required this.selectedModules,
     required this.outputDirectory,
     required this.logger,
+    required this.strictMode,
     this.packageName,
     this.initialRoute,
   });
 
   /// Human-readable project name.
   final String name;
+
   /// Modules selected by the user for inclusion.
   final List<IModuleCodeContributor> selectedModules;
+
   /// Absolute path where files will be generated.
   final String outputDirectory;
+
   /// Optional organization/package name used in identifiers.
   final String? packageName;
+
   /// Optional initial route for the application.
   final String? initialRoute;
+
   /// Logger for interactive feedback and diagnostics.
   final Logger logger;
+
+  /// Strictness mode for generation behavior (errors vs warnings).
+  final StrictMode strictMode;
 }

--- a/packages/smf_flutter_cli/lib/promts/models/project_preferences.dart
+++ b/packages/smf_flutter_cli/lib/promts/models/project_preferences.dart
@@ -12,10 +12,13 @@ class ProjectPreferences {
 
   /// Human-readable project name.
   final String name;
+
   /// Reverse-domain package/organization name.
   final String packageName;
+
   /// Initial route path to show after app launch.
   final String initialRoute;
+
   /// Selected modules to be included in the generated project.
   final List<IModuleCodeContributor> selectedModules;
 }

--- a/packages/smf_flutter_cli/lib/utils/module_creator.dart
+++ b/packages/smf_flutter_cli/lib/utils/module_creator.dart
@@ -1,0 +1,112 @@
+import 'package:mason/mason.dart' show Logger;
+import 'package:smf_contracts/smf_contracts.dart';
+import 'package:smf_flutter_cli/promts/models/cli_context.dart';
+import 'package:smf_flutter_cli/utils/module_dependency_resolver.dart';
+
+/// Builds module instances from factories, enforcing supports(profile)
+/// and populating transitive dependencies from the registry.
+class ModuleCreator {
+  const ModuleCreator(
+    this.resolver,
+    this.registry, {
+    this.coreModuleKeys = const <String>[],
+  });
+
+  final ModuleDependencyResolver resolver;
+  final Map<String, IModuleContributorFactory> registry;
+  final List<String> coreModuleKeys;
+
+  /// Builds module instances using [rootFactories] and [profile].
+  ///
+  /// - Adds core factories (flutter_core, contracts) implicitly via [coreModuleKeys].
+  /// - In strict mode throws when a module or its dependency is unsupported
+  ///   or missing in the registry. In lenient mode logs a warning and skips.
+  List<IModuleCodeContributor> build(
+    List<IModuleContributorFactory> rootFactories,
+    ModuleProfile profile, {
+    required StrictMode strictMode,
+    Logger? logger,
+  }) {
+    final allRequestedFactories = <IModuleContributorFactory>{
+      ...rootFactories,
+      ...coreModuleKeys
+          .map((key) => registry[key])
+          .whereType<IModuleContributorFactory>(),
+    };
+
+    final moduleNameToInstance = <String, IModuleCodeContributor>{};
+    final processedModuleNames = <String>{};
+
+    IModuleCodeContributor? tryCreateModuleInstance(
+      IModuleContributorFactory factory,
+    ) {
+      if (!factory.supports(profile)) {
+        final message = 'Module factory ${factory.runtimeType} '
+            'does not support profile: $profile';
+        if (strictMode == StrictMode.strict) {
+          logger?.err('❌ $message');
+          throw StateError(message);
+        } else {
+          logger?.warn('⚠️ $message. Skipping.');
+          return null;
+        }
+      }
+
+      return factory.create(profile);
+    }
+
+    void addModuleAndDependencies(IModuleCodeContributor module) {
+      final moduleName = module.moduleDescriptor.name;
+      if (processedModuleNames.contains(moduleName)) return;
+      processedModuleNames.add(moduleName);
+
+      for (final dependencyName in module.moduleDescriptor.dependsOn) {
+        final dependencyFactory = registry[dependencyName];
+        if (dependencyFactory == null) {
+          final message = 'Unknown dependency: $dependencyName for $moduleName';
+          if (strictMode == StrictMode.strict) {
+            logger?.err('❌ $message');
+            throw StateError(message);
+          } else {
+            logger?.warn('⚠️ $message. Skipping $moduleName');
+            return; // skip this module in lenient mode
+          }
+        }
+
+        final alreadyPresent = moduleNameToInstance.containsKey(dependencyName);
+        final dependencyInstance = moduleNameToInstance[dependencyName] ??
+            tryCreateModuleInstance(dependencyFactory);
+        if (dependencyInstance == null) {
+          // Unsupported dependency in lenient mode → skip current module
+          logger?.warn(
+            '⚠️ Dependency $dependencyName not available for $moduleName. '
+            'Skipping $moduleName',
+          );
+
+          return;
+        }
+
+        moduleNameToInstance[dependencyName] = dependencyInstance;
+        if (!alreadyPresent) {
+          logger?.detail(
+            '🔗 Resolved transitive dependency: '
+            '$dependencyName (required by $moduleName)',
+          );
+        }
+        addModuleAndDependencies(dependencyInstance);
+      }
+
+      moduleNameToInstance[moduleName] = module;
+    }
+
+    for (final factory in allRequestedFactories) {
+      final instance = tryCreateModuleInstance(factory);
+      if (instance == null) continue;
+      addModuleAndDependencies(instance);
+    }
+
+    // Resolve final order using provided resolver
+    final built = moduleNameToInstance.values.toList();
+    return resolver.resolve(built);
+  }
+}

--- a/packages/smf_flutter_cli/lib/utils/module_dependency_resolver.dart
+++ b/packages/smf_flutter_cli/lib/utils/module_dependency_resolver.dart
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 import 'package:smf_contracts/smf_contracts.dart';
-import 'package:smf_flutter_cli/constants/smf_modules.dart';
 
 /// Resolves transitive module dependencies and returns a topologically
 /// sorted list suitable for generation.
@@ -20,24 +19,29 @@ class ModuleDependencyResolver {
   /// Creates a new [ModuleDependencyResolver].
   const ModuleDependencyResolver();
 
-  /// Returns a sorted list where dependencies appear before dependents.
+  /// Returns a list where dependencies appear before dependents using only
+  /// the provided module instances.
   List<IModuleCodeContributor> resolve(
     List<IModuleCodeContributor> selectedModules,
   ) {
-    final resolved = <String>{};
+    final byName = {
+      for (final m in selectedModules) m.moduleDescriptor.name: m,
+    };
+
+    final visited = <String>{};
     final sorted = <IModuleCodeContributor>[];
 
     void visit(String name) {
-      if (resolved.contains(name)) return;
+      if (visited.contains(name)) return;
 
-      final module = smfModules[name];
-      if (module == null) throw Exception('Unknown module: $name');
+      final module = byName[name];
+      if (module == null) return;
 
       for (final dep in module.moduleDescriptor.dependsOn) {
         visit(dep);
       }
 
-      resolved.add(name);
+      visited.add(name);
       sorted.add(module);
     }
 

--- a/packages/smf_flutter_cli/pubspec.yaml
+++ b/packages/smf_flutter_cli/pubspec.yaml
@@ -38,4 +38,5 @@ dependencies:
 dev_dependencies:
   test: ^1.24.0
   very_good_analysis: ^9.0.0
+  mocktail: ^1.0.4
 

--- a/packages/smf_flutter_cli/test/utils/module_creator_test.dart
+++ b/packages/smf_flutter_cli/test/utils/module_creator_test.dart
@@ -1,0 +1,191 @@
+import 'package:smf_contracts/smf_contracts.dart';
+import 'package:smf_flutter_cli/promts/models/cli_context.dart';
+import 'package:smf_flutter_cli/utils/module_creator.dart';
+import 'package:smf_flutter_cli/utils/module_dependency_resolver.dart';
+import 'package:test/test.dart';
+
+class TestModule
+    with EmptyModuleCodeContributor
+    implements IModuleCodeContributor {
+  TestModule(this._descriptor);
+
+  final ModuleDescriptor _descriptor;
+
+  @override
+  ModuleDescriptor get moduleDescriptor => _descriptor;
+}
+
+class TestFactory implements IModuleContributorFactory {
+  TestFactory({
+    required this.name,
+    required this.description,
+    this.dependsOn = const <String>{},
+    this.supportsProfile = true,
+  });
+
+  final String name;
+  final String description;
+  final Set<String> dependsOn;
+  final bool supportsProfile;
+
+  @override
+  IModuleCodeContributor create(ModuleProfile profile) {
+    return TestModule(
+      ModuleDescriptor(
+        name: name,
+        description: description,
+        dependsOn: dependsOn,
+      ),
+    );
+  }
+
+  @override
+  bool supports(ModuleProfile profile) => supportsProfile;
+}
+
+void main() {
+  group('ModuleCreator', () {
+    late Map<String, IModuleContributorFactory> registry;
+    late ModuleCreator creator;
+    late ModuleDependencyResolver resolver;
+    const profile = ModuleProfile(stateManager: StateManager.bloc);
+
+    setUp(() {
+      registry = <String, IModuleContributorFactory>{};
+      resolver = const ModuleDependencyResolver();
+      creator = ModuleCreator(
+        resolver,
+        registry,
+      );
+    });
+
+    test('includes core via constructor-provided keys', () {
+      creator = ModuleCreator(
+        resolver,
+        registry,
+        coreModuleKeys: const ['core', 'contracts'],
+      );
+      registry['core'] = TestFactory(name: 'core', description: 'Core');
+      registry['contracts'] =
+          TestFactory(name: 'contracts', description: 'Contracts');
+
+      final modules = creator.build(
+        const <IModuleContributorFactory>[],
+        profile,
+        strictMode: StrictMode.lenient,
+      );
+
+      final names = modules.map((m) => m.moduleDescriptor.name).toSet();
+      expect(names, containsAll(['core', 'contracts']));
+    });
+
+    test('creates dependencies from registry when only dependent is selected',
+        () {
+      registry['a'] =
+          TestFactory(name: 'a', description: 'A', dependsOn: {'b'});
+      registry['b'] = TestFactory(name: 'b', description: 'B');
+
+      final modules = creator.build(
+        <IModuleContributorFactory>[registry['a']!],
+        profile,
+        strictMode: StrictMode.lenient,
+      );
+
+      final names = modules.map((m) => m.moduleDescriptor.name).toList();
+      expect(names, containsAll(['a', 'b']));
+    });
+
+    test('skips unsupported root in lenient mode', () {
+      registry['u'] = TestFactory(
+        name: 'u',
+        description: 'Unsupported',
+        supportsProfile: false,
+      );
+
+      final modules = creator.build(
+        <IModuleContributorFactory>[registry['u']!],
+        profile,
+        strictMode: StrictMode.lenient,
+      );
+
+      final names = modules.map((m) => m.moduleDescriptor.name).toSet();
+      expect(names.contains('u'), isFalse);
+    });
+
+    test('throws on unsupported root in strict mode', () {
+      registry['u'] = TestFactory(
+        name: 'u',
+        description: 'Unsupported',
+        supportsProfile: false,
+      );
+
+      expect(
+        () => creator.build(
+          <IModuleContributorFactory>[registry['u']!],
+          profile,
+          strictMode: StrictMode.strict,
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('skips dependent when its dependency is unsupported (lenient)', () {
+      registry['root'] =
+          TestFactory(name: 'root', description: 'Root', dependsOn: {'dep'});
+      registry['dep'] =
+          TestFactory(name: 'dep', description: 'Dep', supportsProfile: false);
+
+      final modules = creator.build(
+        <IModuleContributorFactory>[registry['root']!],
+        profile,
+        strictMode: StrictMode.lenient,
+      );
+
+      final names = modules.map((m) => m.moduleDescriptor.name).toSet();
+      expect(names.contains('root'), isFalse);
+      expect(names.contains('dep'), isFalse);
+    });
+
+    test('throws when dependency is missing in registry (strict)', () {
+      registry['a'] =
+          TestFactory(name: 'a', description: 'A', dependsOn: {'missing'});
+
+      expect(
+        () => creator.build(
+          <IModuleContributorFactory>[registry['a']!],
+          profile,
+          strictMode: StrictMode.strict,
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('skips module when dependency is missing in registry (lenient)', () {
+      registry['a'] =
+          TestFactory(name: 'a', description: 'A', dependsOn: {'missing'});
+
+      final modules = creator.build(
+        <IModuleContributorFactory>[registry['a']!],
+        profile,
+        strictMode: StrictMode.lenient,
+      );
+
+      final names = modules.map((m) => m.moduleDescriptor.name).toSet();
+      expect(names.contains('a'), isFalse);
+    });
+
+    test('deduplicates factories passed multiple times', () {
+      registry['x'] = TestFactory(name: 'x', description: 'X');
+
+      final modules = creator.build(
+        <IModuleContributorFactory>[registry['x']!, registry['x']!],
+        profile,
+        strictMode: StrictMode.lenient,
+      );
+
+      final countX =
+          modules.where((m) => m.moduleDescriptor.name == 'x').length;
+      expect(countX, lessThanOrEqualTo(1));
+    });
+  });
+}

--- a/packages/smf_flutter_cli/test/utils/module_dependency_resolver_test.dart
+++ b/packages/smf_flutter_cli/test/utils/module_dependency_resolver_test.dart
@@ -1,0 +1,63 @@
+import 'package:smf_contracts/smf_contracts.dart';
+import 'package:smf_flutter_cli/utils/module_dependency_resolver.dart';
+import 'package:test/test.dart';
+
+class TestModule
+    with EmptyModuleCodeContributor
+    implements IModuleCodeContributor {
+  TestModule(this._descriptor);
+
+  final ModuleDescriptor _descriptor;
+
+  @override
+  ModuleDescriptor get moduleDescriptor => _descriptor;
+}
+
+IModuleCodeContributor makeModule(
+  String name, {
+  Set<String> dependsOn = const <String>{},
+}) =>
+    TestModule(
+        ModuleDescriptor(name: name, description: name, dependsOn: dependsOn));
+
+void main() {
+  group('ModuleDependencyResolver', () {
+    const resolver = ModuleDependencyResolver();
+
+    test('returns input when there are no dependencies', () {
+      final a = makeModule('a');
+      final b = makeModule('b');
+
+      final result = resolver.resolve([a, b]);
+      expect(result, containsAll([a, b]));
+    });
+
+    test('orders dependencies before dependents', () {
+      final a = makeModule('a');
+      final b = makeModule('b', dependsOn: {'a'});
+
+      final result = resolver.resolve([b, a]);
+      final names = result.map((m) => m.moduleDescriptor.name).toList();
+      final indexA = names.indexOf('a');
+      final indexB = names.indexOf('b');
+      expect(indexA, lessThan(indexB));
+    });
+
+    test('handles deep chains', () {
+      final a = makeModule('a');
+      final b = makeModule('b', dependsOn: {'a'});
+      final c = makeModule('c', dependsOn: {'b'});
+      final d = makeModule('d', dependsOn: {'c'});
+
+      final result = resolver.resolve([d, c, b, a]);
+      final names = result.map((m) => m.moduleDescriptor.name).toList();
+      expect(names, equals(['a', 'b', 'c', 'd']));
+    });
+
+    test('ignores dependencies that are not in the input set', () {
+      final a = makeModule('a', dependsOn: {'ghost'});
+      final result = resolver.resolve([a]);
+      expect(result.first, equals(a));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add ModuleCreator (builds instances from factories + dependencies)
- Add global --strict; plumb into CliContext and BrickGenerator (strict rethrows)
- Log resolved transitive dependencies in verbose mode
- Prompt state manager; compute initialRoute from built instances (exclude core)
- Improve exit handling in bin; keep cli_engine generation unchanged
- Update tests and DI for registry/resolver

BREAKING CHANGE: ProjectPreferences.selectedModules is now List<IModuleCodeContributor>; 

Explain the change in 1–3 sentences.

## Scope

- Affected areas:
  - [x] CLI core
  - [ ] Bricks / templates
  - [x] Generators
  - [x] Prompts / UI
  - [x] File writers
  - [x] Utils / Tooling
  - [ ] Docs/Assets

## Motivation and Context

Why is this change needed? What problem does it solve?

## How Has This Been Tested?

Describe tests performed (commands, scenarios, platforms). Attach screenshots/logs if helpful.

## Checklist

- [ ] Code is clean and readable; comments/strings are in English only
- [ ] `dart format` has been run
- [ ] `dart analyze` shows no new warnings/errors
- [ ] Tests added/updated where appropriate and pass locally
- [ ] User-facing docs or READMEs updated where applicable
- [ ] CHANGELOG updated if behavior changes
- [ ] If bricks/templates changed, ran `dart run tools/bundle_bricks.dart` and committed bundles
- [ ] Avoided module-level installation instructions; modules are integrated via the CLI
- [ ] For Firebase-related flows, project generation occurs before running `flutterfire configure`

## Related Issues

Link to the issue(s) this PR closes or relates to.
