### PR TITLE
fix: add extra space between emoji and message.

### DIFF
--- a/packages/smf_flutter_cli/lib/generators/brick_generator.dart
+++ b/packages/smf_flutter_cli/lib/generators/brick_generator.dart
@@ -70,7 +70,7 @@ class BrickGenerator extends Generator {
 
           if (isStrict) {
             logger.err(
-              '❌ Error in module ${module.moduleDescriptor.name}',
+              '❌  Error in module ${module.moduleDescriptor.name}',
             );
 
             rethrow;
@@ -91,8 +91,7 @@ class BrickGenerator extends Generator {
     }
 
     if (disabledModules.isNotEmpty) {
-      final excludedNames =
-          disabledModules.map((m) => m.moduleDescriptor.name).join(', ');
+      final excludedNames = disabledModules.map((m) => m.moduleDescriptor.name).join(', ');
 
       logger
         ..info('⚠️⚠️⚠️ Generation warnings ⚠️⚠️⚠️')

--- a/packages/smf_flutter_cli/lib/version.dart
+++ b/packages/smf_flutter_cli/lib/version.dart
@@ -2,4 +2,4 @@
 // This file provides the CLI version string without parsing pubspec.
 
 /// The current version of the SMF Flutter CLI.
-const String packageVersion = '0.2.0-alpha';
+const packageVersion = '0.2.0-alpha';


### PR DESCRIPTION
## Summary

Explain the change in 1–3 sentences.

## Scope

- Affected areas:
  - [ ] CLI core
  - [ ] Bricks / templates
  - [ ] Generators
  - [ ] Prompts / UI
  - [ ] File writers
  - [x] Utils / Tooling
  - [ ] Docs/Assets

## Motivation and Context

Why is this change needed? What problem does it solve?

## How Has This Been Tested?

Describe tests performed (commands, scenarios, platforms). Attach screenshots/logs if helpful.

## Checklist

- [ ] Code is clean and readable; comments/strings are in English only
- [ ] `dart format` has been run
- [ ] `dart analyze` shows no new warnings/errors
- [ ] Tests added/updated where appropriate and pass locally
- [ ] User-facing docs or READMEs updated where applicable
- [ ] CHANGELOG updated if behavior changes
- [ ] If bricks/templates changed, ran `dart run tools/bundle_bricks.dart` and committed bundles
- [ ] Avoided module-level installation instructions; modules are integrated via the CLI
- [ ] For Firebase-related flows, project generation occurs before running `flutterfire configure`

## Related Issues

Link to the issue(s) this PR closes or relates to.
